### PR TITLE
Updates to Netatmo driver

### DIFF
--- a/bin/user/netatmo.py
+++ b/bin/user/netatmo.py
@@ -160,7 +160,7 @@ class NetatmoDriver(weewx.drivers.AbstractDevice):
         elif mode.lower() == 'cloud':
             max_tries = int(stn_dict.get('max_tries', 5))
             retry_wait = int(stn_dict.get('retry_wait', 10)) # seconds
-            poll_interval = int(stn_dict.get('poll_interval', 600)) # seconds
+            poll_interval = int(stn_dict.get('poll_interval', 300)) # seconds
             username = stn_dict['username']
             password = stn_dict['password']
             client_id = stn_dict['client_id']
@@ -306,7 +306,7 @@ class CloudClient(Collector):
         'firmware', 'last_setup', 'last_upgrade', 'date_setup']
 
     def __init__(self, username, password, client_id, client_secret,
-                 device_id=None, poll_interval=600, max_tries=3, retry_wait=30):
+                 device_id=None, poll_interval=300, max_tries=3, retry_wait=30):
         self._poll_interval = poll_interval
         self._max_tries = max_tries
         self._retry_wait = retry_wait
@@ -507,7 +507,7 @@ class CloudClient(Collector):
             self._last_update = 0
             self._raw_data = dict()
 
-        def get_data(self, device_id=None, stale=600):
+        def get_data(self, device_id=None, stale=300):
             if int(time.time()) - self._last_update > stale:
                 params = {'access_token': self._auth.access_token}
                 if device_id:

--- a/bin/user/netatmo.py
+++ b/bin/user/netatmo.py
@@ -332,6 +332,8 @@ class CloudClient(Collector):
                                (tries + 1, self._max_tries, e))
                         logdbg("waiting %s seconds before retry" %
                                self.retry_wait)
+                        time.sleep(self.retry_wait)
+                        continue
                 else:
                     logerr("failed to get data after %d attempts" %
                            self._max_tries)

--- a/bin/user/netatmo.py
+++ b/bin/user/netatmo.py
@@ -70,7 +70,7 @@ def logerr(msg):
 def loader(config_dict, engine):
     return NetatmoDriver(**config_dict[DRIVER_NAME])
 
-def confeditor_loader(config_dict):
+def confeditor_loader():
     return NetatmoConfEditor()
 
 
@@ -167,7 +167,7 @@ class NetatmoDriver(weewx.drivers.AbstractDevice):
         else:
             raise ValueError("unsupported mode '%s'" % mode)
         self.collector.startup()
-    
+
     def closePort(self):
         self.collector.shutdown()
 
@@ -247,7 +247,7 @@ class CloudClient(Collector):
       lang: user locale
       reg_locale: regional preferences for date
       feel_like_algo: 0: humidex, 1: heat-index
-    
+
     rf_status is a mapping to rssi (+dB)
       0: 90, 1: 80, 2: 70, 3: 60
     wifi_status is a mapping to rssi (+dB)
@@ -384,7 +384,7 @@ class CloudClient(Collector):
 
     @staticmethod
     def _cvt_speed(x, from_unit_dict):
-        # windunit: 0: kph, 1: mph, 2: m/s, 3: beafort, 4: knot        
+        # windunit: 0: kph, 1: mph, 2: m/s, 3: beafort, 4: knot
         if from_unit_dict['windunit'] == 1:
             x *= MPH_TO_KPH
         elif from_unit_dict['windunit'] == 2:
@@ -510,7 +510,7 @@ class CloudClient(Collector):
         resp_obj = json.loads(resp)
         logdbg("resp_obj: %s" % resp_obj)
         return resp_obj
-        
+
 
 class PacketSniffer(Collector):
     """listen for incoming packets then parse them.  put result on queue."""

--- a/bin/user/netatmo.py
+++ b/bin/user/netatmo.py
@@ -138,7 +138,7 @@ class NetatmoDriver(weewx.drivers.AbstractDevice):
         '*.NAModule2.rf_status': 'rf_status',
         '*.NAModule2.battery_vp': 'battery_vp',
         '*.NAModule3.Rain': 'rain',
-        '*.NAModule3.sum_rain_1': 'rainRate',
+        #'*.NAModule3.sum_rain_1': 'rainRate',
         '*.NAModule3.sum_rain_24': 'rain_total',
         '*.NAModule3.rf_status': 'rf_status',
         '*.NAModule3.battery_percent': 'rainBatteryStatus'}
@@ -232,7 +232,7 @@ class NetatmoDriver(weewx.drivers.AbstractDevice):
         if 'rain_total' in packet:
             #convert from mm to cm for total rain
             packet['rain_total'] = packet['rain_total'] / 10
-            packet['rainRate'] = packet['rainRate'] / 10
+            #packet['rainRate'] = packet['rainRate'] / 10
             total = packet['rain_total']
             if (total is not None and self.last_rain is not None and
                 total < self.last_rain):
@@ -298,7 +298,7 @@ class CloudClient(Collector):
     # these items are tracked from every module and every device
     DASHBOARD_ITEMS = [
         'Temperature', 'Humidity', 'AbsolutePressure', 'Pressure',
-        'CO2', 'Noise', 'Rain', 'sum_rain_24', 'sum_rain_1',
+        'CO2', 'Noise', 'Rain', 'sum_rain_24', #'sum_rain_1',
         'WindStrength', 'WindAngle', 'GustStrength', 'GustAngle']
     META_ITEMS = [
         'wifi_status', 'rf_status', 'battery_vp', 'co2_calibrating',

--- a/readme.txt
+++ b/readme.txt
@@ -19,20 +19,32 @@ obtained via the dev.netatmo.com web site.  Using these 4 things, the driver
 automatically obtains and updates the tokens needed to get data from the
 server.
 
+<SG> 
+I had to make some changes to Matt's code to get it to work correctly 
+for me installation wise.
+
+I had to tweak the packet sent to weewx to convert the mm to cm.
+
+I also updated the way the rain was counted to match what some other drivers 
+were doing (new daily total - old daily total give you rain from last check).  
+
+Lastly, I updated this to actually use the rain rate provided by the netatmo
+and also saved the battery status of the outdoor unit and the rain gauge.
+</SG>
 
 Installation instructions:
 
 0) download the driver:
 
-wget -O weewx-netatmo.zip https://github.com/matthewwall/weewx-netatmo/archive/master.zip
+wget -O weewx-netatmo.zip https://github.com/scottgrey/weewx-netatmo/archive/master.zip
 
 1) install the driver:
 
-wee_extension --install weewx-netatmo.zip
+sudo wee_extension --install weewx-netatmo.zip
 
 2) select and configure the driver:
 
-wee_config --reconfigure
+sudo wee_config --reconfigure
 
 3) start weewx:
 

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,10 @@ Lastly, I updated this to actually use the rain rate provided by the netatmo
 and also saved the battery status of the outdoor unit and the rain gauge.
 </SG>
 
+<SG>
+Removed the rain rate, wasn't showing on PWSWeather correctly
+</SG>
+
 Installation instructions:
 
 0) download the driver:

--- a/readme.txt
+++ b/readme.txt
@@ -19,14 +19,14 @@ obtained via the dev.netatmo.com web site.  Using these 4 things, the driver
 automatically obtains and updates the tokens needed to get data from the
 server.
 
-<SG> 
-I had to make some changes to Matt's code to get it to work correctly 
+<SG>
+I had to make some changes to Matt's code to get it to work correctly
 for me installation wise.
 
 I had to tweak the packet sent to weewx to convert the mm to cm.
 
-I also updated the way the rain was counted to match what some other drivers 
-were doing (new daily total - old daily total give you rain from last check).  
+I also updated the way the rain was counted to match what some other drivers
+were doing (new daily total - old daily total give you rain from last check).
 
 Lastly, I updated this to actually use the rain rate provided by the netatmo
 and also saved the battery status of the outdoor unit and the rain gauge.
@@ -34,6 +34,10 @@ and also saved the battery status of the outdoor unit and the rain gauge.
 
 <SG>
 Removed the rain rate, wasn't showing on PWSWeather correctly
+</SG>
+
+<SG>
+Updating time to check from 600 seconds to 300 seconds
 </SG>
 
 Installation instructions:


### PR DESCRIPTION
I had to make some updates to the driver to give me more accurate results in weewx as well as when it was uploading to pwsweather and wunderground.  A few problems I had to fix:
1. Calculate rain changes like other drivers where it creates the 'rain' field in the packet based on the old total and the new total.
2. Change confeditor_loader to not take a parameter since this wasn't working for me.
3. Added in the battery status for the outdoor module and the rain gauge.  I don't have a wind gauge yet, so I didn't fool around with that part at all.
4. Changed the timing of the loops from 600 seconds to 300 seconds to more closely mimic how often the data is updated at netatmo.
5. Fixed an issue where if it received a 502 from netatmo, it would essentially just die.  I haven't had a chance to make sure this is actually working in practice, but I think in the try except in collect_data it would issue one 502 error and then never continue to try again.  So I added the actual time.sleep and then a continue and I think this should allow it to retry.  This is the only part I'm not 100% comfortable with yet.

Take a look and let me know what you think or if you think I need to change anything with this.
